### PR TITLE
Adds support for rendering templates from files

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "async": "~0.2.6",
     "consolidate": "~0.8.0",
-    "juice": "~1.0.0"
+    "juice": "~1.7.0"
   },
   "devDependencies": {
     "coffee-script": "~1.7.1",

--- a/src/email-juicer.coffee
+++ b/src/email-juicer.coffee
@@ -39,20 +39,20 @@ class EmailTemplate
   renderHtml: (options, fn) =>
     handleResults = (err, data) =>
       unless err
-        data = juice(data, {extraCss: @css, applyStyleTags: true}) if @css?
+        data = juice(data, {extraCss: @css, applyStyleTags: true, preserveImportant: true}) if @css?
       fn err, data
 
     if @html?
       @renderTemplate @html, options, handleResults
-    else if @htmlFile
+    else if @htmlFile?
       @renderTemplateFromFile @htmlFile, options, handleResults
     else
       fn null, ''
 
   renderText: (options, fn) =>
-    if @text
+    if @text?
       @renderTemplate @text, options, fn
-    else if @textFile
+    else if @textFile?
       @renderTemplateFromFile @textFile, options, fn
     else
       fn null, ''


### PR DESCRIPTION
- Bumps juice version to 1.7 to support `preserveImportant`
- Adds option to pass in template file paths instead of just template content
- Supports Jade templates properly
